### PR TITLE
Fix issue with Keep PP Laser Puzzle being unable to generate

### DIFF
--- a/Source/Special.cpp
+++ b/Source/Special.cpp
@@ -676,6 +676,7 @@ void Special::generateKeepLaserPuzzle(int id, const std::set<Point>& path1, cons
 		solution.push_back(row);
 	}
 
+	int failedCount = 0;
 	while (!generator->place_all_symbols(psymbols)) {
 		for (int x = 0; x < generator->_panel->_width; x++)
 			for (int y = 0; y < generator->_panel->_height; y++)
@@ -685,6 +686,14 @@ void Special::generateKeepLaserPuzzle(int id, const std::set<Point>& path1, cons
 		for (int i = 0; i < psymbols.symbols[Decoration::Poly].size(); i++) {
 			psymbols.symbols[Decoration::Poly][i].second = psymbolsBackup.symbols[Decoration::Poly][i].second + Random::rand() % 3 - Random::rand() % 3;
 			if (psymbols.symbols[Decoration::Poly][i].second < 1) psymbols.symbols[Decoration::Poly][i].second = 1;
+		}
+
+		// Variety issue where sometimes the squares can't be placed: Remove more and more of one of the square colors
+		failedCount++;
+		if (failedCount == 10000 && psymbols.symbols.contains(0x100) && psymbols.symbols[0x100].size() > 3) {
+			psymbols.symbols[0x100].back().second--;
+			if (psymbols.symbols[0x100][0].second == 0) psymbols.symbols[0x100].pop_back();
+			failedCount = 0;
 		}
 	}
 


### PR DESCRIPTION
In Variety, Keep PP Laser Puzzle wants
5 Black Squares, 4 White Squares, 5 Cyan Squares, 4 Magenta Sqaures.

However, it is (rarely) possible that the paths for the small PP puzzles end up making these square counts impossible to satisfy.

Here is an example:
![image](https://github.com/user-attachments/assets/6782ad06-0ff5-40d9-9552-93b0993965b0)

There are only 4 regions, and one of them is way too small to fit 4 Magenta or 4 White squares.

This change makes it so that after some large amount of failed generation attempts, one of the Magenta squares is removed - This is repeated until a successful generation happens.

In this case, we end up with this puzzle:
![image](https://github.com/user-attachments/assets/a4c550ae-183a-49cb-8ae3-db30684672ec)

Which still has one Magenta square, the maximum possible.